### PR TITLE
Fix QQ login issue if the redirect url with query parameters.

### DIFF
--- a/socialoauth/sites/base.py
+++ b/socialoauth/sites/base.py
@@ -7,6 +7,7 @@ from functools import wraps
 
 from socialoauth.exception import SocialAPIError, SocialSitesConfigError
 from socialoauth import SocialSites
+import urllib
 
 HTTP_TIMEOUT = 10
 
@@ -115,7 +116,7 @@ class OAuth2(object):
         """
 
         url = "%s?client_id=%s&response_type=code&redirect_uri=%s" % (
-            self.AUTHORIZE_URL, self.CLIENT_ID, self.REDIRECT_URI
+            self.AUTHORIZE_URL, self.CLIENT_ID, urllib.quote_plus(self.REDIRECT_URI)
         )
 
         if getattr(self, 'SCOPE', None) is not None:


### PR DESCRIPTION
For example, the redirect url looks like below,

/account/oauth/qq?returnurl=previouspath

Following the documentation of Oauth 2.0 of QQ, the 'redirect_uri' should be encoded.

http://wiki.connect.qq.com/%E4%BD%BF%E7%94%A8authorization_code%E8%8E%B7%E5%8F%96access_token#Step1.EF.BC.9A.E8.8E.B7.E5.8F.96AuthorizationCode
